### PR TITLE
:hammer: show STDOUT when deployment failed on Action

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,9 +38,9 @@ async function run(): Promise<void> {
     settings.tenant = core.getInput('tenant')
     settings.clientId = core.getInput('clientId')
     settings.clientSecret = core.getInput('clientSecret')
-    settings.addAppInsightsStep = core.getInput('addAppInsightsStep')  === true || core.getInput('addAppInsightsStep') === 'true'
-    settings.renumberSteps = core.getInput('renumberSteps')  === true || core.getInput('renumberSteps') === 'true'
-    settings.verbose = core.getInput('verbose')  === true || core.getInput('verbose') === 'true'
+    settings.addAppInsightsStep = core.getInput('addAppInsightsStep') === true || core.getInput('addAppInsightsStep') === 'true'
+    settings.renumberSteps = core.getInput('renumberSteps') === true || core.getInput('renumberSteps') === 'true'
+    settings.verbose = core.getInput('verbose') === true || core.getInput('verbose') === 'true'
     let deploymentType = DeploymentType.None
 
     core.info('Deploy custom policy GitHub Action v5.3 started.')
@@ -137,7 +137,6 @@ async function run(): Promise<void> {
 
         // Replace yourtenant.onmicrosoft.com with the tenant name parameter
         if (policyXML.indexOf("yourtenant.onmicrosoft.com") > 0) {
-          //core.info(`Policy ${filePath} replacing yourtenant.onmicrosoft.com with ${tenant}.`)
           policyXML = policyXML.replace(new RegExp("yourtenant.onmicrosoft.com", "gi"), settings.tenant)
         }
 
@@ -178,6 +177,8 @@ async function run(): Promise<void> {
     }
 
   } catch (error: any) {
+    core.info(`Deployment Failed`)
+    core.info(error)
     const errorText = error.message ?? error
     core.setFailed(errorText)
   }


### PR DESCRIPTION
Hi, thank you for the great Actions.

When I run this action, I found that I cannot get any error output on the Github Actions console.
I tested this module on my local and I found the causes of the error.

Now, I want to add `core.info` to show the error output.

Maybe other developers have similar issues.

https://github.com/azure-ad-b2c/deploy-trustframework-policy/issues/118